### PR TITLE
Add graphite to the VSCode extensions.json recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -16,6 +16,7 @@
         "ms-python.debugpy",
         "mechatroner.rainbow-csv",
         "charliermarsh.ruff",
-        "rangav.vscode-thunder-client"
+        "rangav.vscode-thunder-client",
+        "graphite.gti-vscode"
     ]
 }


### PR DESCRIPTION
Added the `graphite.gti-vscode` extension to improve code review process and collaboration in VSCode.

---

